### PR TITLE
BUGFIX: Reading Cloudinary uploader API key from environment variables

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+require("dotenv").config();
 
 const connectDB = async () => {
   try {

--- a/middleware/cloudinary.js
+++ b/middleware/cloudinary.js
@@ -1,3 +1,4 @@
+require("dotenv").config();
 const cloudinary = require("cloudinary").v2;
 
 cloudinary.config({

--- a/middleware/cloudinary.js
+++ b/middleware/cloudinary.js
@@ -1,5 +1,5 @@
-require("dotenv").config();
 const cloudinary = require("cloudinary").v2;
+require("dotenv").config();
 
 cloudinary.config({
   cloud_name: process.env.CLOUD_NAME,


### PR DESCRIPTION
Discovered during testing that the Create Recipe modal was not allowing us to upload images which prevented the recipe from being created. Testing on the codebase prior to refactoring the reading of the environment variables works, so we are going to re-introduce the `dotenv` module's reading of the vars back into the two files from which they were removed.